### PR TITLE
unprecise event name

### DIFF
--- a/docs/provisioning/slack-events-api.md
+++ b/docs/provisioning/slack-events-api.md
@@ -61,7 +61,7 @@ Once verified, click "Add Bot User Event", and using the dropdown that appears, 
 
 * `message.channels`
 * `message.groups`
-* `message.ims`
+* `message.im`
 *  `message.mpim`
 
 This configuration tells Slack to send your bot all messages that are sent in any channel or group in which your bot is present. Add other events as needed. 


### PR DESCRIPTION
Just a minor issue: The event name "message.ims" is now actually called "message.im". Fixed it in line 64.