### PR TITLE
Fix smart quotation marks and add link to FB personas documentation

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -917,7 +917,7 @@ controller.api.insights.get_insights('page_messages_active_threads_unique', null
 
 ## Personas API
 
-The Facebook Personas API allows a business to introduce a virtual “persona” into the thread. 
+The [Facebook Personas API](https://developers.facebook.com/docs/messenger-platform/send-messages/personas/) allows a business to introduce a virtual "persona" into the thread. 
 
 To create a new persona :
 ```javascript


### PR DESCRIPTION
I noticed that v0.7.0 had the new Facebook personas API (thanks @ouadie-lahdioui) but the documentation had incorrect quotation marks. Fixed that issue and linked to the FB personas documentation.