### PR TITLE
Fixes small typo in slack documentation

### DIFF
--- a/docs/readme-slack.md
+++ b/docs/readme-slack.md
@@ -338,7 +338,7 @@ controller.setupWebserver(process.env.port,function(err,webserver) {
 ```
 
 
-### Send an interactive message uing Attachments
+### Send an interactive message using Attachments
 ```javascript
 controller.hears('interactive', 'direct_message', function(bot, message) {
 


### PR DESCRIPTION
This is the tiniest change, which fixes a tiny typo in the slack adapter documentation 